### PR TITLE
docs: sync benchmark profile budgets with the run-shape matrix

### DIFF
--- a/docs/current/AEGIS_AGENTIC_BENCHMARK_BASELINE.md
+++ b/docs/current/AEGIS_AGENTIC_BENCHMARK_BASELINE.md
@@ -196,12 +196,12 @@ The matrix is the only exact run-shape owner. It defines these profiles:
 
 | Profile | Cases | Repetitions | Valid target | Attempt ceiling | Workers | Wall budget | Publication |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| `development-pilot` | 1 development | 1 | 2 | 2 | 2 | 600 seconds | disabled |
-| `standard-held-out` | all 20 held-out | 1 | 40 | 44 | 8 | 3600 seconds | advisory; `repeated-run-evidence` unsupported |
-| `extended-held-out` | all 20 held-out | 3 | 120 | 132 | 8 | 9000 seconds | advisory repeated-run evidence |
+| `development-pilot` | 1 development | 1 | 2 | 2 | 2 | 1200 seconds | disabled |
+| `standard-held-out` | all 20 held-out | 1 | 40 | 44 | 8 | 7200 seconds | advisory; `repeated-run-evidence` unsupported |
+| `extended-held-out` | all 20 held-out | 3 | 120 | 132 | 8 | 18000 seconds | advisory repeated-run evidence |
 
 Every profile uses both live comparison arms, a 30-second provider preflight,
-a 480-second per-attempt timeout, and an infrastructure failure limit of two
+a 960-second per-attempt timeout, and an infrastructure failure limit of two
 completed attempts in a wave. The maximum supported worker count is 12. An
 incomplete batch must not feed public benchmark claims.
 


### PR DESCRIPTION
## What problem are you trying to solve?

`docs/current/AEGIS_AGENTIC_BENCHMARK_BASELINE.md` states four run-shape values
that contradict the matrix fixture the same section names as their owner.

The section opens with:

> The matrix is the only exact run-shape owner. It defines these profiles:

…and then restates the profile table. Four of those restated numbers are stale
— each one is exactly half of the value currently in
`tests/e2e/fixtures/agentic-benchmark-matrix.json`:

| Value | Baseline doc (lines 199-201, 204) | Matrix fixture (lines 134-191) |
| --- | ---: | ---: |
| `development-pilot` wall budget | 600 seconds | **1200** |
| `standard-held-out` wall budget | 3600 seconds | **7200** |
| `extended-held-out` wall budget | 9000 seconds | **18000** |
| per-attempt timeout | 480 seconds | **960** |

Root cause is traceable to a single commit. `c38a24a6`
(`perf: double agentic benchmark budgets for slow providers`, shipped in
v2.6.9) changed four files:

```
tests/e2e/agentic-benchmark-check.sh
tests/e2e/fixtures/agentic-benchmark-matrix.json
tests/helpers/test_run_agentic_benchmark.py
tests/helpers/validate_agentic_benchmark_matrix.py
```

The v2.6.9 release note for that change says the three profile definitions
("check 脚本内嵌、校验脚本、fixture 矩阵") were kept in sync. The prose baseline
is a fourth place that also restates those values, and it was not updated.

Concrete impact: the baseline docs are the documented authority read order for
non-trivial work (`AGENTS.md` → `docs/current/README.md` → task-relevant
`docs/current/*.md`). An agent or contributor sizing a benchmark run from this
table plans against half the real ceiling — for `extended-held-out`, 9000s
instead of 18000s. Nothing in the suite compares the prose table against the
matrix, so this drift is silent: the three profile assertions in
`agentic-benchmark-check.sh` pass identically before and after this change
(verified below), because they assert profile presence and policy wording, not
the numeric values.

## What does this PR change?

Updates four stale numbers in `docs/current/AEGIS_AGENTIC_BENCHMARK_BASELINE.md`
to match `tests/e2e/fixtures/agentic-benchmark-matrix.json`. Documentation only
— no code, fixture, test, or behavior change.

## Is this change appropriate for the core library?

Yes. It corrects a `docs/current/` authority document that ships with the
method pack and is part of the documented read order for every user, on every
project type. It is not project-specific, team-specific, or tool-specific, and
it introduces no third-party service or integration.

## What alternatives did you consider?

1. **Remove the numbers from the prose table entirely**, leaving the matrix as
   the sole carrier. Rejected: the section's stated purpose is to describe what
   the matrix defines, and the surrounding prose depends on those figures
   (the wall-clock budget paragraph immediately after explains what the ceiling
   covers). Deleting the table also removes useful reference material, and that
   editorial call belongs to the maintainer, not to an outside contributor.
2. **Extend the automated checks so the prose table is compared against the
   matrix**, which would prevent the next recurrence rather than fixing this
   instance. Rejected *for this PR* because it is a separate, unrelated change
   to the test suite and would bundle two changes into one PR. I am happy to
   open it separately if you want it.
3. **Open an issue instead of a PR.** `CONTRIBUTING.md` asks for issue-first on
   non-trivial changes; a four-number correction with a traceable root cause is
   trivial enough that a diff is faster to review than a description. Happy to
   convert to an issue if you prefer that ordering.

## Does this PR contain multiple unrelated changes?

No. One file, four lines, one concern: aligning stale restated values with the
fixture that owns them.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found — at the time of writing this repository has no open
  PRs, and no closed-unmerged PRs; the only merged PRs are the maintainer's own.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (used to prepare and verify this change) | 2.1.221 | Claude Opus 5 | `claude-opus-5[1m]` |

Verification commands were run on macOS 26.6 (Darwin 25.6.0), bash 5.x,
Python 3.14.6, against `main` at `fe34c3c` (v2.6.9).

## Evaluation

This is a documentation value correction with no behavior surface, so
before/after eval sessions are not the applicable instrument — there is no
agent behavior to measure, and I did not run any. What I did instead was verify
correctness of the values and prove the change is regression-free against a
stashed baseline:

**1. Value correctness.** Each new number read directly out of
`tests/e2e/fixtures/agentic-benchmark-matrix.json`
(`wallClockBudgetSeconds` = 1200 / 7200 / 18000, `perAttemptTimeoutSeconds`
= 960 on all three profiles), cross-checked against the v2.6.9 release note and
against commit `c38a24a6`.

**2. Scope check — nothing else drifted.** Every other value in the table was
compared to the fixture and matches: repetitions 1/1/3, valid target 2/40/120,
attempt ceiling 2/44/132, workers 2/8/8, preflight 30s, max workers 12. Those
are left untouched.

**3. Repo-wide sweep for other stale copies.** Grepped the whole tree for the
old values; the only occurrences outside this file are in `RELEASE-NOTES.md`,
where they are historical `600→1200` change records and must stay.

**4. Before/after regression proof** (change stashed, re-run, unstashed):

| Check | `main` @ `fe34c3c` | With this change |
| --- | --- | --- |
| `tests/e2e/agentic-benchmark-check.sh` | 55 pass, 0 fail, exit 1 | 55 pass, 0 fail, exit 1 |
| `tests/e2e/layer1-fast-check.sh --host-profile none` | Passed: 35, Failed: 1 | Passed: 35, Failed: 1 |
| `git diff --check` | clean | clean |

A line-by-line diff of the `[PASS]`/`[FAIL]` output from both `layer1-fast-check`
runs is empty — results are identical item for item.

The single failure in both columns is `agentic benchmark policy`, caused by
`offline Codex fixture platform is unsupported` on macOS. It reproduces on the
unmodified baseline, and it matches what the v2.6.9 release note already records
for this gate ("layer1-fast-check 35/36", the only failure being the
environment-limited offline Codex fixture platform check). It is pre-existing
and unrelated to this change.

## Rigor

- [ ] If this is a skills change: I used `aegis:writing-skills` and
      completed adversarial pressure testing (paste results below)
      — *not applicable: no file under `skills/` is touched.*
- [x] This change was tested adversarially, not just on the happy path
      — *rather than fixing only the discrepancy I first noticed, I diffed
      every value in the table against the fixture (step 2 above), swept the
      whole repo for other stale copies (step 3), and ran the suite on a
      stashed baseline to prove the pre-existing failure was not introduced
      here (step 4).*
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement
      — *no behavior-shaping prose changed; only four numeric literals.*

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

The complete diff is four lines in one file and was reviewed in full before
submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark profile time limits.
  * Increased development, standard held-out, and extended held-out budgets.
  * Doubled the maximum time allowed for each attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->