### PR TITLE
fix: report malformed marker paths relative to the scan root

### DIFF
--- a/scripts/aegis-deferred-ledger.py
+++ b/scripts/aegis-deferred-ledger.py
@@ -85,7 +85,12 @@ def parse_line(path: Path, root: Path, line_number: int, line: str) -> tuple[Led
         try:
             fields = parse_fields(payload)
         except ValueError as exc:
-            return None, LedgerIssue(path.as_posix(), line_number, f"cannot parse marker fields: {exc}", line.strip())
+            return None, LedgerIssue(
+                path.relative_to(root).as_posix(),
+                line_number,
+                f"cannot parse marker fields: {exc}",
+                line.strip(),
+            )
         missing = [field for field in REQUIRED_FIELDS if not fields.get(field)]
         if missing:
             return None, LedgerIssue(

--- a/tests/helpers/test_aegis_deferred_ledger.py
+++ b/tests/helpers/test_aegis_deferred_ledger.py
@@ -58,6 +58,21 @@ def test_reports_missing_required_fields() -> None:
     assert "verification" in issues[0].message
 
 
+def test_issue_paths_are_repository_relative() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write(root / "docs" / "unparsable.md", f'# {FOLLOWUP} owner="docs\n')
+        write(root / "docs" / "incomplete.md", f"# {FOLLOWUP} owner=docs\n")
+
+        entries, issues = ledger.collect(root)
+
+    assert not entries
+    assert sorted(issue.path for issue in issues) == [
+        "docs/incomplete.md",
+        "docs/unparsable.md",
+    ]
+
+
 def test_ignores_markdown_fenced_examples() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)


### PR DESCRIPTION
## What problem are you trying to solve?

While preparing #11 I ran `scripts/aegis-deferred-ledger.py` against a scratch tree that contained both a marker with an unbalanced quote and a marker missing required fields. The single `Malformed markers:` list came back with two different path formats:

```
Malformed markers:
- /private/tmp/claude-501/.../dl-lab/sub/bad_quote.txt:1 cannot parse marker fields: No closing quotation
- sub/missing.txt:1 missing fields: trigger, verification
```

`main()` does `root = Path(args.root).resolve()` and `iter_files()` walks that resolved root, so every `path` reaching `parse_line` is absolute. `LedgerEntry` (`:100`) and the missing-fields `LedgerIssue` (`:92`) both normalize with `path.relative_to(root).as_posix()`; the shlex-failure branch (`:88`) passed `path.as_posix()` straight through and was the only site that did not.

Two concrete effects:

- Anything that filters, greps, or matches `issues[].path` against repository-relative paths matches the missing-fields issues and silently skips the parse-error ones — the "this marker is so broken the parser choked" class is exactly the one you least want dropped.
- `--json` embeds the home directory of whichever machine ran the scan, so ledger output is not safe to paste into an issue or commit without editing.

You flagged this yourself in the #11 review ("noted on the separate `parse_line` path inconsistency; that one is worth its own PR"), which is why this is a separate PR rather than a follow-up commit there.

## What does this PR change?

`parse_line`'s shlex-failure branch now builds `LedgerIssue` with `path.relative_to(root).as_posix()`, matching the other two construction sites in the same function. Adds `test_issue_paths_are_repository_relative`, which puts one unparsable and one incomplete marker under `docs/` and asserts both issue paths come back repository-relative.

## Is this change appropriate for the core library?

Yes. `scripts/aegis-deferred-ledger.py` is repository infrastructure that ships with the method pack and is wired into `tests/e2e/deferred-ledger-check.sh` → `layer1-fast-check.sh`. The fix is not project-specific, adds no dependency, introduces no runtime authority, and does not change what the scanner considers a valid marker — only how it names files it already reports.

## What alternatives did you consider?

- **Normalize at the `LedgerIssue` boundary instead** (e.g. a `__post_init__` or a factory taking `root`). Rejected as heavier than the defect warrants: three construction sites in one function, two already correct. Adding a normalization layer changes the dataclass contract to fix a single missed call.
- **Normalize downstream in `render_text`/`main`** so `parse_line` can stay as-is. Rejected because the inconsistency would still be visible to anyone importing `collect()` directly — which is how `tests/helpers/test_aegis_deferred_ledger.py` uses it — so the invariant would hold only for the CLI path.
- **Make the absolute form the standard and change the other two sites.** Rejected: `LedgerEntry.path` is relative, the docs and the check script treat marker locations as repo paths, and absolute paths make `--json` output machine-specific.
- **Fix without a test.** Rejected — this is a one-token change with no compile-time or lint pressure holding it in place, so a regression test is what keeps it fixed.

## Does this PR contain multiple unrelated changes?

No. One behavior fix plus the test that pins it.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #11 (adjacent — added the runner that lets this file's tests execute at all; this PR's test is only meaningful because #11 landed). No open PRs; no prior art for this defect.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | 2.1.221 | Claude Opus 5 (1M context) | claude-opus-5[1m] |

Agent-assisted, human-reviewed: the diff, the failure reproduction, and this description were reviewed line by line by me before submission.

## Evaluation

**Initial prompt that led here:** a routine pass over my open contributions to this repo, which surfaced your #11 review note about `parse_line`. Not a fresh session-failure report — the defect was found by running the scanner, not by a model misbehaving.

**Verification runs after the change (macOS 15 / Python 3.14.6, plus Linux / Ubuntu 24.04 / Python 3.12.3):**

1. **Reproduction before the fix** — scratch tree with one unbalanced-quote marker and one missing-field marker under `sub/`: text output and `--json` both returned one absolute and one relative path (quoted above).
2. **Red/green on the new test** — with the fix in place, all four tests `[PASS]`, exit 0. Reverting only line 88 back to `path.as_posix()`: `[FAIL] test_issue_paths_are_repository_relative`, exit 1, the other three still `[PASS]`. Restoring the fix: 4/4 `[PASS]`, exit 0. The failure propagates through the gate — `deferred-ledger-check.sh` exits 1 with the revert in place.
3. **Both platforms** — the injection cycle above was run on macOS and on Linux, same verdicts. `test_issue_paths_are_repository_relative` compares a `sorted()` list, so it does not depend on `os.walk` ordering (the failure mode that bit #11 on your CI).
4. **Stashed-baseline regression** — `layer1-fast-check.sh --host-profile none` on macOS: 35 pass / 1 fail before and after, `[PASS]`/`[FAIL]` lines diff to empty; the single failure is the known offline-Codex-fixture platform limitation noted in the v2.6.9 release notes. On Linux the same run is 36 pass / 0 fail, before and after.
5. `git diff --check` clean; `--json` output on the scratch tree no longer contains a home-directory path.

**Before/after difference:** the mixed-format `issues` list is gone — every `LedgerIssue.path` is now repository-relative regardless of which branch produced it — and the gate can now fail if that regresses, which it could not before.

## Rigor

- [ ] If this is a skills change: I used `aegis:writing-skills` and
      completed adversarial pressure testing (paste results below)

  Not a skills change — no `skills/**` file is touched, so no behavior-shaping content is modified.

- [x] This change was tested adversarially, not just on the happy path

  The test drives the parser through the branch that only fires on `shlex` raising, and the fix was validated by reverting it and confirming the test and the gate both fail — not just by observing a green run.

- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

  No prose, skill text, or baseline document is touched.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed marker-field errors now display file paths relative to the scan root.
  * Issue paths are consistently sorted for clearer, more predictable reporting.

* **Tests**
  * Added coverage for relative paths, multiple issue files, and sorted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->