### PR TITLE
docs: correct the isolation claims in the explicit-skill-request runner

### DIFF
--- a/tests/explicit-skill-requests/run-test.sh
+++ b/tests/explicit-skill-requests/run-test.sh
@@ -5,7 +5,9 @@
 # Tests whether Claude invokes a skill when the user explicitly requests it by name
 # (without using the plugin namespace prefix)
 #
-# Uses isolated HOME to avoid user context interference
+# Runs in a scratch project directory, but under the caller's real HOME, so the
+# locally installed Claude Code environment (user CLAUDE.md, skills, agents) is
+# in scope for every run
 
 set -e
 
@@ -81,7 +83,7 @@ Create login and register endpoints.
 Protect routes with JWT validation.
 EOF
 
-# Run CLI with isolated environment
+# Run CLI in the scratch project directory
 if [ "$TEST_CLI" = "codex" ]; then
     LOG_FILE="$OUTPUT_DIR/codex-output.log"
 else


### PR DESCRIPTION
## What problem are you trying to solve?

`tests/explicit-skill-requests/run-test.sh` opens with:

```
# Uses isolated HOME to avoid user context interference
```

and again at the launch site (`:84`):

```
# Run CLI with isolated environment
```

Neither is true. The only `HOME` occurrence in the whole file is that first comment — the script never assigns `HOME`. What it does isolate is the workspace: it builds a fresh timestamped `PROJECT_DIR` under `/tmp/aegis-tests/<ts>/…/project` and `cd`s into it. `HOME` stays whatever the caller has, so `~/.claude` (personal `CLAUDE.md`, installed skills, agents, plugins) is fully in scope.

I measured it on the runner's own invocation shape (`claude -p … --plugin-dir <repo> --output-format stream-json --verbose`, from a checkout of this repo) and read the `system`/`init` event: **153 slash commands exposed, 12 of them personally installed skills that do not exist in this repository** — e.g. `deep-research-ryan-*`, `notes-summarize-*`, `taichung-weather`. For a suite whose entire subject is *which skill gets invoked when the user names one*, foreign skills in the same namespace are exactly the interference the comment promises is absent. A maintainer reading a red or green result here would reasonably over-trust it.

This is stale prose rather than broken isolation, and two things in the repo say so:

- `tests/explicit-skill-requests/run-haiku-test.sh:26-27` deliberately copies `$HOME/.claude/CLAUDE.md` into the scratch project "to simulate real environment" — the suite's actual posture is *use the local environment*, which is the opposite of what the comment claims.
- The repo does know how to build genuine isolated homes where it wants them (`tests/helpers/agentic_benchmark_isolation.py` writes a per-arm Codex home). So the concept exists; this suite simply is not one of its users.

## What does this PR change?

Two comments in `tests/explicit-skill-requests/run-test.sh` now describe what the script actually does: a scratch project directory under the caller's real `HOME`, with the local Claude Code environment in scope. No executable line is touched.

## Is this change appropriate for the core library?

Yes. It is repository test infrastructure shipped with the method pack, and the correction is about the accuracy of the evidence this suite produces — not about any project-specific workflow. No dependency, no runtime authority, no behavior change.

## What alternatives did you consider?

- **Add real isolation (`HOME=$(mktemp -d)`) and keep the comment.** Rejected as not mine to decide: the Claude CLI reads its credentials from `HOME`, so a bare temp `HOME` would leave the runner unauthenticated. Doing it properly means a curated home (credentials in, user skills out), which is a design choice with a maintenance cost — your call, not a drive-by change from an outside contributor. If you want it, say so and I will open a separate PR.
- **Delete both comments.** Rejected: the first one is load-bearing for a reader deciding how much to trust a result. Saying "your local environment is in scope" is more useful than saying nothing.
- **Also annotate `tests/skill-triggering/run-test.sh`** (same shape, no isolation). Rejected: it makes no false claim, so touching it would be scope creep in a PR about correcting one.
- **Open an issue instead of a PR.** Considered — the underlying question (do you want real isolation?) is issue-shaped, but the false comment is a concrete, self-contained correction, so the smaller move is to land the accuracy fix and raise the design question in the description.

## Does this PR contain multiple unrelated changes?

No. Two comments in one file, both restating the same incorrect claim.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found. (#10 and #11 are mine and unrelated in subject, though #10 was the same class of defect — prose that stopped matching the code it describes.)

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | 2.1.221 | Claude Opus 5 (1M context) | claude-opus-5[1m] |

Agent-assisted, human-reviewed: the diff, the measurement, and this description were reviewed line by line before submission.

## Evaluation

**Initial prompt that led here:** a pass over remaining contribution candidates in this repo, triaging which were real defects and which were only tidiness. Two candidates from the same batch were discarded after checking them properly — one because a downstream guard already prevented the failure I had assumed, one because the apparent contradiction was a deliberate metaphor read in isolation. This one survived because the claim is checkable and false.

**Verification after the change (macOS 15 / bash 3.2; the change is comments only, so there is no runtime behavior to A/B):**

1. **The measurement above** — 153 slash commands / 12 foreign skills, read out of the `system`/`init` event of the runner's own invocation shape.
2. **Sweep to zero** — `grep -rn 'isolated HOME\|isolated environment' tests/explicit-skill-requests/` returns 0 after the change (2 before).
3. **Nothing else touched** — `isolated` counts in `tests/e2e/agentic-benchmark-check.sh` (3), `tests/opencode/setup.sh` (2), `tests/helpers/agentic_benchmark_isolation.py` (5) are unchanged; those are genuine isolation and should keep the word.
4. **Syntax** — `bash -n tests/explicit-skill-requests/run-test.sh` clean.
5. **Stashed-baseline regression** — `layer1-fast-check.sh --host-profile none` before and after: 35 pass / 1 fail both, `[PASS]`/`[FAIL]` lines diff to empty. The single failure is the known environment-bound offline Codex fixture check, unrelated. `git diff --check` clean.

**Before/after difference:** a reader of this runner no longer starts from a false premise about what the test controls for. Nothing executes differently.

## Rigor

- [ ] If this is a skills change: I used `aegis:writing-skills` and
      completed adversarial pressure testing (paste results below)

  Not a skills change — no `skills/**` file is touched.

- [x] This change was tested adversarially, not just on the happy path

  The claim was not taken at face value in either direction: I checked whether isolation existed anywhere in the file, whether a sibling script contradicted the intent, and then measured the actual contamination rather than asserting it.

- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

  No skill text, prose baseline, or behavior-shaping content is touched.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated explicit-skill request test execution to run from a scratch project directory.
  * Improved test coverage of CLI behavior while preserving the caller’s home environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->