### PR TITLE
fix: keep retry headroom from lowering a richer benchmark profile

### DIFF
--- a/docs/current/AEGIS_AGENTIC_BENCHMARK_BASELINE.md
+++ b/docs/current/AEGIS_AGENTIC_BENCHMARK_BASELINE.md
@@ -454,8 +454,9 @@ binding limits instead of stopping the batch at the first paired-canary or
 circuit-open transport failure. This exists because custom provider networks
 can drop streams transiently; without it, one wave-1 transport failure aborts
 the whole batch. For the same reason, `AEGIS_AGENTIC_BENCHMARK_RETRY_HEADROOM=1`
-projects the provider-track batch with a higher paid-attempt ceiling (64) and
-wall-clock budget (7200s) than the frozen matrix profile; both values are
+raises the provider-track paid-attempt ceiling to at least 64 and the
+wall-clock budget to at least 7200s; the headroom acts as a floor, so a profile
+whose frozen values are already larger keeps its own. Both values are
 frozen into the batch digest and `verify_batch` compares them against the same
 projection, so a provider track can absorb transient failures inside one batch
 instead of ending partial.

--- a/tests/helpers/run_agentic_benchmark.py
+++ b/tests/helpers/run_agentic_benchmark.py
@@ -325,8 +325,13 @@ def profile_fields(profile: dict[str, Any]) -> dict[str, Any]:
     )}
     fields.update(profileId=profile["id"], repetitions=profile["repetitionsPerCase"], targetRunCount=profile["validRunTarget"], maxAttempts=profile["paidAttemptCeiling"])
     if retry_headroom_enabled():
-        fields["maxAttempts"] = RETRY_HEADROOM_MAX_ATTEMPTS
-        fields["wallClockBudgetSeconds"] = RETRY_HEADROOM_WALL_SECONDS
+        # Headroom is a floor, never a cap: profiles whose frozen ceiling or
+        # budget already exceeds the headroom constants keep their own values.
+        # Overwriting unconditionally lowered extended-held-out from 132/18000
+        # to 64/7200, which the scheduler then rejected because maxAttempts
+        # fell below the frozen schedule length.
+        fields["maxAttempts"] = max(fields["maxAttempts"], RETRY_HEADROOM_MAX_ATTEMPTS)
+        fields["wallClockBudgetSeconds"] = max(fields["wallClockBudgetSeconds"], RETRY_HEADROOM_WALL_SECONDS)
     return fields
 
 

--- a/tests/helpers/test_run_agentic_benchmark.py
+++ b/tests/helpers/test_run_agentic_benchmark.py
@@ -1328,6 +1328,23 @@ class PromptPolicyTest(unittest.TestCase):
             self.assertEqual(fields["maxAttempts"], benchmark_runner.RETRY_HEADROOM_MAX_ATTEMPTS)
             self.assertEqual(fields["wallClockBudgetSeconds"], benchmark_runner.RETRY_HEADROOM_WALL_SECONDS)
 
+    def test_retry_headroom_never_lowers_a_frozen_profile(self):
+        root = Path(__file__).resolve().parents[2]
+        matrix_path = root / "tests" / "e2e" / "fixtures" / "agentic-benchmark-matrix.json"
+        profiles = json.loads(matrix_path.read_text(encoding="utf-8"))["runProfiles"]
+        self.assertTrue(profiles)
+        for profile in profiles:
+            with self.subTest(profile=profile["id"]):
+                with mock.patch.dict(os.environ, {}, clear=False):
+                    if "AEGIS_AGENTIC_BENCHMARK_RETRY_HEADROOM" in os.environ:
+                        del os.environ["AEGIS_AGENTIC_BENCHMARK_RETRY_HEADROOM"]
+                    frozen = benchmark_runner.profile_fields(profile)
+                with mock.patch.dict(os.environ, {"AEGIS_AGENTIC_BENCHMARK_RETRY_HEADROOM": "1"}, clear=False):
+                    headroom = benchmark_runner.profile_fields(profile)
+                self.assertGreaterEqual(headroom["maxAttempts"], frozen["maxAttempts"])
+                self.assertGreaterEqual(headroom["wallClockBudgetSeconds"], frozen["wallClockBudgetSeconds"])
+                self.assertGreaterEqual(headroom["maxAttempts"], headroom["targetRunCount"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What problem are you trying to solve?

`AEGIS_AGENTIC_BENCHMARK_RETRY_HEADROOM=1` is documented as giving a provider track *more* room than the frozen profile. For `extended-held-out` it does the opposite, and the batch cannot start at all.

`profile_fields` (`tests/helpers/run_agentic_benchmark.py:327-329`) assigned the two headroom constants unconditionally, ignoring what the profile already had. Projected against the real matrix (`tests/e2e/fixtures/agentic-benchmark-matrix.json`), run on Linux:

```
profile                 ceil  ->hr    wall    ->hr  verdict
development-pilot          2    64    1200  7200.0  raised OK
standard-held-out         44    64    7200  7200.0  wall NOT raised
extended-held-out        132    64   18000  7200.0  LOWERED  <-- opposite of documented
                        ^ scheduler fail-closed: maxAttempts=64 < schedule=120
```

So the opt-in was a raise for one profile out of three, a no-op on the budget for the second, and a downgrade on both values for the third.

The third case does not merely shrink the batch — it cannot run. `extended-held-out` has `validRunTarget: 120`, `run_agentic_benchmark.py:385` requires `targetRunCount == len(schedule)`, and `agentic_benchmark_scheduler._validate_policy` (`:130`) rejects any batch whose `maxAttempts` is below the frozen schedule length. Driving that guard with the projected fields:

```
extended-held-out: SystemExit -> maxAttempts cannot be smaller than the frozen schedule
```

`extended-held-out` plus retry headroom is therefore an unusable combination, and the operator who tries it gets an error about the frozen schedule rather than anything pointing at the opt-in they just set.

The baseline text promising "a higher paid-attempt ceiling (64) and wall-clock budget (7200s) than the frozen matrix profile" is accurate for `development-pilot` only.

## What does this PR change?

`profile_fields` now takes `max(profile value, headroom constant)` for both fields, so headroom is a floor rather than an overwrite. Adds `test_retry_headroom_never_lowers_a_frozen_profile`, and rewrites the one baseline sentence that promised the values are higher for every profile.

## Is this change appropriate for the core library?

Yes. This is the method pack's own benchmark harness under `tests/helpers/`, wired into `tests/e2e/agentic-benchmark-check.sh`. The change is not project-specific, adds no dependency, introduces no runtime authority, and does not touch the scoring contract, arm isolation, or what counts as a valid attempt. It only stops one opt-in from contradicting the matrix that owns the run shape.

It also does not alter default behavior: with the variable unset, `profile_fields` returns exactly what it returned before.

## What alternatives did you consider?

- **Document the limitation instead of fixing it** — say headroom is for `standard-held-out` only. Rejected: the broken combination stays reachable, and the failure surfaces as `maxAttempts cannot be smaller than the frozen schedule`, which names neither the opt-in nor the profile. A doc note does not stop an operator from setting an env var.
- **Guard in the scheduler** — let `_validate_policy` tolerate a ceiling below the schedule when headroom is on. Rejected: that fail-closed check is correct and protects every batch. Loosening a global invariant to accommodate one opt-in is the wrong direction, and it would still leave `extended-held-out` silently running on 40% of its wall budget.
- **Per-profile headroom constants** in the matrix. Rejected as heavier than the defect warrants: three profiles would need three tuned pairs kept in sync with the frozen values they shadow, which is the same drift this PR removes. A floor needs no per-profile maintenance and stays correct if the profiles are retuned again.
- **Multiply the frozen values** (e.g. 1.5x) rather than take a floor. Rejected: it changes the projection for every profile including ones that are fine today, and the two constants are already frozen into the batch digest, so a multiplier would silently reshape existing expectations.
- **Fix without a test.** Rejected — this is a two-line change with no lint or type pressure holding it in place, and the existing headroom test uses a profile (44 / 3600) that both the old and the new code satisfy, so it cannot catch a regression here.

## Does this PR contain multiple unrelated changes?

No. One behavior fix, the test that pins it, and the one baseline sentence that describes that exact behavior. The doc edit is not separable: it is the sentence the code was contradicting.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #10 (adjacent — corrected the profile table in this same baseline document after the budgets were doubled; that PR fixed the table's numbers, this one fixes a different paragraph in the same file plus the projection code). No open PRs at all in this repo right now; no prior art for this defect.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | 2.1.226 | Claude Opus 5 (1M context) | claude-opus-5[1m] |

Agent-assisted, human-reviewed: the diff, the reproduction, and this description were reviewed line by line by me before submission.

## Evaluation

**Initial prompt that led here:** a routine pass over open contribution candidates for this repo, reading the benchmark baseline against the frozen matrix. Not a session-failure report — the defect was found by projecting the profiles through `profile_fields`, not by a model misbehaving.

**Verification runs after the change.** All of it ran on Linux (Ubuntu 24.04 / Python 3.12.3), because `run_agentic_benchmark` imports `agentic_benchmark_provider_preflight`, which needs `fcntl.F_SEAL_*` and cannot be imported on macOS at all:

1. **Reproduction before the fix** — the projection table and the `SystemExit` quoted above, produced by driving `profile_fields` and `_validate_policy` with the real matrix.
2. **Red/green on the new test** — with the fix in place, 47 tests pass, exit 0. Reverting only the two assignment lines back to unconditional overwrite: exactly one failure, `test_retry_headroom_never_lowers_a_frozen_profile` at `subTest(profile='extended-held-out')` with `AssertionError: 64 not greater than or equal to 132`, exit 1; the other 46 still pass. Restoring the fix: 47 pass, exit 0.
3. **Existing tests unchanged** — `test_profile_fields_apply_retry_headroom_only_when_enabled` still passes untouched. Its fixture profile is 44 / 3600, and `max(44, 64)` and `max(3600.0, 7200.0)` give the same values it already asserted.
4. **Stashed-baseline regression, both gates** — `layer1-fast-check.sh --host-profile none`: 36 pass / 0 fail before and after, `[PASS]`/`[FAIL]` lines diff to empty. `agentic-benchmark-check.sh`: 188 pass / 0 fail before and after, `[PASS]`/`[FAIL]` lines diff to empty, exit 0 both times.
5. `git diff --check` clean.

**Before/after difference:** `extended-held-out` with headroom enabled goes from a batch that exits on the frozen-schedule guard to one that keeps its own 132 / 18000, and the gate can now fail if that regresses, which it could not before. `standard-held-out` and `development-pilot` project identically to before.

**New test reads the fixture rather than hard-coding numbers**, so if the profiles are retuned again the assertion follows them instead of going stale — the same reason the runner added in #11 discovers tests instead of listing them.

## Rigor

- [ ] If this is a skills change: I used `aegis:writing-skills` and
      completed adversarial pressure testing (paste results below)

  Not a skills change — no `skills/**` file is touched, so no behavior-shaping content is modified.

- [x] This change was tested adversarially, not just on the happy path

  The revert-and-rerun cycle in step 2 is the adversarial half: the point was to confirm the new test actually fails when the fix is absent, and fails on the specific profile, rather than passing for an unrelated reason. The `subTest` label identifies which profile broke.

- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

  No skill text, no agent-facing prose. The only prose change is one sentence of the benchmark baseline that stated a behavior the code did not have.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark retry-headroom handling so configured attempt limits and time budgets are treated as minimums.
  * Existing larger profile limits are now preserved rather than reduced.
  * Retry-enabled benchmark runs receive sufficient capacity for reliable completion.

* **Tests**
  * Added regression coverage to verify retry settings never lower frozen profile limits or target run counts.

* **Documentation**
  * Updated benchmark baseline documentation to reflect the revised retry limits and time budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->