### PR TITLE
fix: accept both frozen skill-path spellings in the prompt-input marker

### DIFF
--- a/tests/helpers/agentic_benchmark_isolation.py
+++ b/tests/helpers/agentic_benchmark_isolation.py
@@ -972,7 +972,14 @@ def prompt_input_summary(data: Any, prompt: str, expected_skill_ids: list[str]) 
         "roleCounts": dict(sorted(roles.items())),
         "textBytes": len(text.encode()),
         "promptOccurrences": text.count(prompt),
-        "methodPackMarkerCount": text.count(f"{VIRTUAL_SNAPSHOT}/skills"),
+        # Codex <= 0.146 resolves the skill-projection symlink and prints the
+        # snapshot path; Codex >= 0.147 prints the discovery path itself. Both
+        # spellings are frozen layout constants, so either one is proof that
+        # the distribution snapshot reached the prompt input.
+        "methodPackMarkerCount": (
+            text.count(f"{VIRTUAL_SNAPSHOT}/skills")
+            + text.count(f"{VIRTUAL_HOME}/.agents/skills/aegis")
+        ),
         "evaluatedSkillMatchCount": len(matched_skills),
         "evaluatedSkillMatches": matched_skills,
     }

--- a/tests/helpers/test_agentic_benchmark_preflight.py
+++ b/tests/helpers/test_agentic_benchmark_preflight.py
@@ -882,6 +882,32 @@ class CommandBoundaryTest(unittest.TestCase):
                     prompt_input_summary(drifted, "absent", [])["nonSkillInputHash"],
                 )
 
+    def test_method_pack_marker_accepts_both_frozen_path_spellings(self):
+        def summary_for(text):
+            data = [
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": text}],
+                }
+            ]
+            return prompt_input_summary(data, "absent", [])
+
+        snapshot_form = summary_for("skill at /opt/aegis/skills/goal-framing/SKILL.md")
+        discovery_form = summary_for(
+            "skill at /home/benchmark/.agents/skills/aegis/goal-framing/SKILL.md"
+        )
+        both_forms = summary_for(
+            "/opt/aegis/skills/a/SKILL.md and /home/benchmark/.agents/skills/aegis/b/SKILL.md"
+        )
+        baseline_form = summary_for(
+            "no skills here; /home/benchmark/.agents/skills exists but is empty"
+        )
+        self.assertEqual(snapshot_form["methodPackMarkerCount"], 1)
+        self.assertEqual(discovery_form["methodPackMarkerCount"], 1)
+        self.assertEqual(both_forms["methodPackMarkerCount"], 2)
+        self.assertEqual(baseline_form["methodPackMarkerCount"], 0)
+
     def test_command_validation_rejects_no_proxy_and_unexpected_proxy_keys(self):
         layout = prepare_provider_preflight_layout(self.scratch / "validate-layout", self.auth)
         base = build_provider_preflight_command(


### PR DESCRIPTION
## What problem are you trying to solve?

#37. On Codex CLI >= 0.147.0 every live benchmark invocation dies during isolation setup with `benchmark active invocation failed`, zero model calls. The underlying `require` failure is `Aegis prompt input contains no distribution snapshot marker`: `methodPackMarkerCount` counts the literal `/opt/aegis/skills` in the `codex debug prompt-input` dump, but the virtualized layout exposes the snapshot to Codex through the symlink `~/.agents/skills/aegis -> /opt/aegis/skills`, and 0.147 stopped resolving that symlink when printing skill paths. A/B on an identical layout: 0.146 prints the real path 22 times and the symlink path 0 times; 0.147 prints the real path 0 times and the symlink path 22 times. So on 0.147 the marker count is always zero and setup fails 100% of the time.

## What does this PR change?

`prompt_input_summary` now counts both frozen spellings of the skill-projection path — the snapshot form `/opt/aegis/skills` and the in-sandbox discovery form `/home/benchmark/.agents/skills/aegis` — plus a regression test covering both forms, their sum, and the baseline-arm zero case.

## Is this change appropriate for the core library?

Yes — it repairs the benchmark harness's own isolation gate for a host it already supports. No skills, no runtime surface, no third-party integration.

## What alternatives did you consider?

- **Pin Codex to <= 0.146 in preflight and refuse newer versions.** Rejected as the primary fix: it turns a one-line observability drift into a permanent version ceiling, and the preflight already records the Codex version for the report.
- **Count only the discovery-path form.** Rejected: it would break the check on <= 0.146, which resolves the symlink. Counting both frozen constants keeps the gate version-agnostic; both spellings are layout invariants, and the baseline arm can produce neither (its home has no `.agents/skills/aegis` at all), so the baseline-must-be-zero check is untouched.
- **Have the layout copy the tree instead of symlinking, so the discovery path is the only real path.** Rejected: `prepare_arm_layout` deliberately symlinks in the virtualized branch so the read-only bind mount stays the single source; changing mount semantics to fix a string count is the wrong layer.

## Does this PR contain multiple unrelated changes?

No. One production line-group (the marker expression plus a comment) and one test.

Note for the issue's secondary point (worker stderr being discarded): not touched here — happy to send it separately so this stays single-purpose.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found (closest prior art is #15/#16 in the same harness area; no PR touches the prompt-input marker)

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | 2.1.226 | Claude Fable 5 | claude-fable-5[1m] |

Agent-assisted, human-reviewed: the diff, the reproduction, and this description were reviewed by me before submission.

## Evaluation

**Initial prompt that led here:** preparing the v2.9.2 / v2.9.4 benchmark baseline batches discussed in the QQ group; the very first pilot run died in isolation setup before any model call, which is what started the investigation.

**Verification runs after the change** (Ubuntu 24.04.4, bubblewrap 0.9.0, Python 3.12.3 — macOS cannot import the preflight helpers at all):

1. **Reproduction before the fix** — pilot on stock v2.9.4 with codex-cli 0.147.0: `isolation-and-setup-failed`, zero attempts. The 0.146-vs-0.147 path-form A/B (22:0 vs 0:22) is in #37.
2. **Red/green on the new test** — fixed branch: 48 preflight tests pass. Reverting only `agentic_benchmark_isolation.py` back to main while keeping the new test: exactly one failure (`test_method_pack_marker_accepts_both_frozen_path_spellings`); restoring the fix: green again.
3. **End-to-end unblock on 0.147** — development-pilot with codex-cli 0.147.0 on the fixed branch: isolation setup passes and the batch completes 2/2 valid, 0 invalid. (Operational note for anyone reproducing with a standalone binary install: 0.147 also needs its new `codex-code-mode-host` sibling on PATH, or every attempt fails as `attempt-tool-execution-unobserved` — that's a Codex packaging matter, not an Aegis defect; npm installs vendor it.)
4. **No regression on 0.146** — same pilot with codex-cli 0.146.0 on the fixed branch: 2/2 valid, 0 invalid.
5. **Suites** — `agentic-benchmark-check.sh` passed; `layer1-fast-check.sh --host-profile none` 36 PASS with the one pre-existing environment-bound FAIL (`DeepSeek Harness host boundary`) identical on pristine main; `git diff --check` clean.

**Before/after difference:** on 0.147 the harness goes from unable to start any live batch to completing a pilot cleanly; 0.146 behavior is unchanged.

## Rigor

- [ ] If this is a skills change: I used `aegis:writing-skills` and completed adversarial pressure testing (paste results below)

  Not a skills change — no `skills/**` file is touched.

- [x] This change was tested adversarially, not just on the happy path (revert-red/restore-green, both Codex versions live, baseline-zero case asserted)
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of method-pack markers across supported skill paths.
  - Correctly counts multiple markers and ignores empty skill directories.

- **Tests**
  - Added regression coverage for snapshot and skill-discovery paths, including mixed marker formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->